### PR TITLE
DNN9 support

### DIFF
--- a/HttpModules/UrlRewriteModuleUtils.cs
+++ b/HttpModules/UrlRewriteModuleUtils.cs
@@ -506,7 +506,7 @@ namespace Satrabel.HttpModules
                 return true;
             }
             */
-            if (WorkUrl.ToLower().StartsWith("/desktopmodules/"))
+            if (WorkUrl.ToLower().StartsWith("/desktopmodules/") || WorkUrl.ToLower().StartsWith("/api/"))
             {
                 return true;
             }


### PR DESCRIPTION
Fixes Persona sidebar breaking in DNN9 due to /API/ url being caught by OpenUrlRewriter