### PR TITLE
Fix for null reference exception on View Rules modal

### DIFF
--- a/UrlRule_View.ascx.cs
+++ b/UrlRule_View.ascx.cs
@@ -28,10 +28,11 @@ namespace Satrabel.Modules.OpenUrlRewriter
 
                 GridView1.DataSource = UrlRuleController.GetUrlRules(PortalId).OrderByDescending(r=> r.RuleType).ThenByDescending(r => r.Parameters);
                 GridView1.DataBind();
-
-
             }
-            GridView1.HeaderRow.TableSection = TableRowSection.TableHeader;
+            if (GridView1.Rows.Count > 0)
+            {
+                GridView1.HeaderRow.TableSection = TableRowSection.TableHeader;
+            }
         }
 
         protected string EditUrlRule(object oUrlRuleId)


### PR DESCRIPTION
When you clear the rules and click "view rules" you'll get a null reference exception as GridView1's HeaderRow is null